### PR TITLE
added restrictionUniqueName

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "filedropper",
-  "version": "1.3.2",
+  "version": "1.4.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "filedropper",
-      "version": "1.3.2",
+      "version": "1.4.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@bem-react/classname": "^1.5.8",

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "filedropper",
   "widgetName": "FileDropper",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "description": "Drop files in your Mendix Application",
   "copyright": "Mendix 2020",
   "author": "Jelte Lagendijk <jelte.lagendijk@mendix.com>",
   "config": {
-    "widgetPath": "./dist/MxTestProject/widgets",
-    "projectPath": "./dist/MxTestProject/",
+    "widgetPath": "../../widgets",
+    "projectPath": "../../",
     "mendixHost": "http://windows:8080",
     "developmentPort": "3000"
   },

--- a/src/FileDropper.tsx
+++ b/src/FileDropper.tsx
@@ -92,6 +92,7 @@ class FileDropperContainer extends Component<FileDropperContainerProps, {}> {
             autoSave: props.dataAutoSave,
             maxNumber: props.restrictionMaxFileCount,
             maxSize: maxFileSize,
+            uniqueName: props.restrictionUniqueName,
             validationMessages,
             accept,
             texts,

--- a/src/FileDropper.xml
+++ b/src/FileDropper.xml
@@ -77,6 +77,10 @@
 Note 1: This might not always be accurate. There can be differences between platforms &amp; browsers. To be sure it is better to use the 'onAccept Microflow'
 Note 2: When using an Entity that is/inherits 'System.Image', Mime types will always be ignored and set to 'image/*'. You can further restrict this using the 'onAccept Microflow'</description>
             </property>
+            <property key="restrictionUniqueName" type="boolean" required="true" defaultValue="true">
+                <caption>Restrict Duplicates</caption>
+                <description>Restrict uploads to have unique names. If true, will ignore a file upload with a repeated name, regardless of file path.</description>
+            </property>
         </propertyGroup>
 
         <!-- VERIFICATION -->

--- a/src/package.xml
+++ b/src/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="FileDropper" version="1.4.1" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="FileDropper" version="1.5.0" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
             <widgetFile path="FileDropper.xml"/>
         </widgetFiles>

--- a/typings/FileDropperProps.d.ts
+++ b/typings/FileDropperProps.d.ts
@@ -39,6 +39,7 @@ export interface FileDropperContainerProps extends CommonProps {
     restrictionMaxFileSize: number;
     restrictionMaxFileCount: number;
     restrictionMimeType: string;
+    restrictionUniqueName: boolean;
 
     verificationOnAcceptMicroflow: string;
     verificationEntity: string;


### PR DESCRIPTION
Feature addition:
- added ability to accept documents with different paths with the same name
- added ability to accept documents with the same path with the same name
toggleable by the restrictionUniqueName property

default behavior is unchanged